### PR TITLE
Source map support / manifest generation error messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "diff": "^5.1.0",
         "js-yaml": "^4.1.0",
+        "source-map-support": "^0.5.21",
         "typed-rest-client": "^1.8.9"
       },
       "devDependencies": {
@@ -1487,8 +1488,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -4799,7 +4799,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4808,7 +4807,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -6650,8 +6648,7 @@
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "call-bind": {
       "version": "1.0.2",
@@ -9114,14 +9111,12 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "diff": "^5.1.0",
     "js-yaml": "^4.1.0",
+    "source-map-support": "^0.5.21",
     "typed-rest-client": "^1.8.9"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import 'source-map-support/register';
+
 import { readFile } from 'fs';
 import { promisify } from 'util';
 import * as core from '@actions/core';
@@ -140,6 +142,13 @@ async function upsertApplication(args: ActionArgs) {
   });
 
   const webUiUrl = `${args.gitWebUrl}/blob/${args.gitSha}`;
+
+  try {
+    await app.toManifest();
+  } catch (err) {
+    core.error(err);
+    throw err;
+  }
 
   const manifestDiff = createTwoFilesPatch(
     `${args.valuesFile}.original`,


### PR DESCRIPTION
Adds the following:
- Source map support (stacktraces will be for ts files not transpiled files)
- Uses `core.error` for `toManifest` errors (to better clarify missing tokens)
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.0.1-next.3`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - Source map support / manifest generation error messages [#4](https://github.com/ejhayes/action-argocd-deploy/pull/4) ([@ejhayes](https://github.com/ejhayes))
  
  #### ⚠️ Pushed to `next`
  
  - adding fixtures ([@ejhayes](https://github.com/ejhayes))
  - using different token to trigger build ([@ejhayes](https://github.com/ejhayes))
  - Adding next build ([@ejhayes](https://github.com/ejhayes))
  
  #### Authors: 1
  
  - Eric Hayes ([@ejhayes](https://github.com/ejhayes))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
