### PR TITLE
feat: add configurable repo and revision config

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,10 +44,10 @@ jobs:
           INPUT_PROJECT: default
           INPUT_TOKENS: '{"TAG": "latest"}'
           INPUT_VALUESFILE: fixtures/values.yaml
-          INPUT_REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-          INPUT_REPO_WEBURL: ${{ github.server_url }}/${{ github.repository }}
-          INPUT_REPO_REVISION: ${{ github.sha }}
-          INPUT_PR_NUMBER: ${{ github.event.number }}
+          INPUT_REPOURL: ${{ github.server_url }}/${{ github.repository }}
+          INPUT_REPOWEBURL: ${{ github.server_url }}/${{ github.repository }}
+          INPUT_REPOREVISION: ${{ github.sha }}
+          INPUT_PRNUMBER: ${{ github.event.number }}
         run: node dist/index.js
       - name: Version Dry Run
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,6 +44,10 @@ jobs:
           INPUT_PROJECT: default
           INPUT_TOKENS: '{"TAG": "latest"}'
           INPUT_VALUESFILE: fixtures/values.yaml
+          INPUT_REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          INPUT_REPO_WEBURL: ${{ github.server_url }}/${{ github.repository }}
+          INPUT_REPO_REVISION: ${{ github.sha }}
+          INPUT_PR_NUMBER: ${{ github.event.number }}
         run: node dist/index.js
       - name: Version Dry Run
         env:

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ inputs:
   valuesFile:
     description: 'Values file to pass to ArgoCD'
     required: true
-  
+
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,21 @@ inputs:
   project:
     description: 'Argo project to create application in'
     required: true
+  prNumber:
+    description: 'PR number'
+    default: ${{ github.event.number }}
+  repoRevision:
+    description: Repo revision to deploy
+    required: false
+    default: ${{ github.sha }}
+  repoUrl:
+    description: Repo URL to deploy
+    required: false
+    default: ${{ github.server_url }}/${{ github.repository }}
+  repoWebUrl:
+    description: Repo web url
+    required: false
+    default: ${{ github.server_url }}/${{ github.repository }}
   tokens:
     description: 'Key/Value list of tokens to replace in helm chart'
     required: false
@@ -57,6 +72,7 @@ inputs:
   valuesFile:
     description: 'Values file to pass to ArgoCD'
     required: true
+  
 runs:
   using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
# What changed

Move repo and revision config to action defaults instead of being determined in the action. These still default to the same values as before but can be overridden if needed. Also update pull requests to specify targetrevision of pull/<number>/head instead of provided sha which causes issues in argocd. This may need to be rethought in the future for non github repos

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.2.0-next.1`

<details>
  <summary>Changelog</summary>

  ### Release Notes
  
  #### feat: add configurable repo and revision config ([#60](https://github.com/ejhayes/action-argocd-deploy/pull/60))
  
  If you want to add additional information to the release notes include them here. Otherwise omit this section.
  -->
  
  ---
  
  #### 🚀 Enhancement
  
  - feat: add configurable repo and revision config [#60](https://github.com/ejhayes/action-argocd-deploy/pull/60) ([@ejhayes](https://github.com/ejhayes) [@GitHub-Action](https://github.com/GitHub-Action))
  
  #### Authors: 2
  
  - [@GitHub-Action](https://github.com/GitHub-Action)
  - Eric Hayes ([@ejhayes](https://github.com/ejhayes))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
