### PR TITLE
Set required to false for clientId/Secret as part of #44

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,10 +18,10 @@ inputs:
     required: true
   clientId:
     description: 'ArgoCD Client Id / Username'
-    required: true
+    required: false
   clientSecret:
     description: 'ArgoCD Client Secret / Password'
-    required: true
+    required: false
   clusterName:
     description: 'Cluster name to deploy to'
     required: true


### PR DESCRIPTION
# What changed

Bug from #44. Ensure that `clientId` and `clientSecret` are not required in `action.yml`